### PR TITLE
Add support for s3_scheme

### DIFF
--- a/src/plugins/nkfile_s3.erl
+++ b/src/plugins/nkfile_s3.erl
@@ -90,6 +90,7 @@ store_syntax() ->
             aws_secret => binary,
             host => binary,
             port => integer,
+            scheme => binary,
             '__mandatory' => [bucket, aws_id, aws_secret]
         }
     }.
@@ -109,7 +110,8 @@ get_config(#{config:=Config}) ->
         true ->
             Host = maps:get(host, Config),
             Port = maps:get(port, Config, 80),
-            AwsConfig2 = AwsConfig#aws_config{s3_host=to_list(Host), s3_port=Port},
+            Scheme = maps:get(scheme, Config, <<"https">>),
+            AwsConfig2 = AwsConfig#aws_config{s3_host=to_list(Host), s3_scheme=to_list(Scheme), s3_port=Port},
             {to_list(Bucket), AwsConfig2}
     end.
 

--- a/src/plugins/nkfile_s3.erl
+++ b/src/plugins/nkfile_s3.erl
@@ -91,7 +91,11 @@ store_syntax() ->
             host => binary,
             port => integer,
             scheme => binary,
-            '__mandatory' => [bucket, aws_id, aws_secret]
+            '__mandatory' => [bucket, aws_id, aws_secret],
+            '__defaults' => #{
+                port => 80,
+                scheme => <<"https://">>
+            }
         }
     }.
 
@@ -109,8 +113,8 @@ get_config(#{config:=Config}) ->
             {to_list(Bucket), AwsConfig};
         true ->
             Host = maps:get(host, Config),
-            Port = maps:get(port, Config, 80),
-            Scheme = maps:get(scheme, Config, <<"https">>),
+            Port = maps:get(port, Config),
+            Scheme = maps:get(scheme, Config),
             AwsConfig2 = AwsConfig#aws_config{s3_host=to_list(Host), s3_scheme=to_list(Scheme), s3_port=Port},
             {to_list(Bucket), AwsConfig2}
     end.


### PR DESCRIPTION
By default, erlcloud assumes https://.
In our deployments, we might want to use http:// (eg. LeoFS).